### PR TITLE
fix: GLib Bytes unref bug

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
       "import": "./dist/esm/build.mjs",
       "require": "./dist/cjs/build.cjs"
     },
-    "./polyfills/*": "./polyfills/esm/*.mjs"
+    "./polyfills/esm/*.mjs": "./polyfills/esm/*.mjs"
   },
   "version": "1.0.0",
   "scripts": {

--- a/src/esbuild-plugins/import-polyfills/create-node-polyfill-map.ts
+++ b/src/esbuild-plugins/import-polyfills/create-node-polyfill-map.ts
@@ -1,9 +1,7 @@
 import type esbuild from "esbuild";
 import path from "path";
 import type { Config } from "../../config/config-type";
-import { getDirPath } from "../../get-dirpath/get-dirpath";
 import type { DeepReadonly, Program } from "../../programs/base";
-import { POLYFILL_IMPORT_NS } from "./import-polyfills";
 
 type PolyfillMapDef = {
   matcher: RegExp;
@@ -14,15 +12,19 @@ type PolyfillMapDef = {
 export const createNodePolyfillMap = (polyfills: Array<PolyfillMapDef>) => {
   return {
     addResolvers(program: Program, build: esbuild.PluginBuild) {
-      const rootPath = getDirPath();
-
       for (const pollyfill of polyfills) {
         if (pollyfill.configFlag(program.config)) {
-          build.onResolve({ filter: pollyfill.matcher }, () => {
-            return {
-              path: path.resolve(rootPath, "polyfills/esm", pollyfill.filename),
-              namespace: POLYFILL_IMPORT_NS,
-            };
+          build.onResolve({ filter: pollyfill.matcher }, (args) => {
+            return build.resolve(
+              "react-gnome/" + path.join("polyfills/esm", pollyfill.filename),
+              {
+                importer: args.importer,
+                namespace: args.namespace,
+                kind: args.kind,
+                pluginData: args.pluginData,
+                resolveDir: args.resolveDir,
+              }
+            );
           });
         }
       }

--- a/src/esbuild-plugins/import-polyfills/import-polyfills.ts
+++ b/src/esbuild-plugins/import-polyfills/import-polyfills.ts
@@ -28,12 +28,11 @@ const NodePolyfills = createNodePolyfillMap([
   {
     matcher: /^(os)|(node:os)$/,
     configFlag: (c) => !!c.polyfills?.node?.os,
-    filename: "os.mjs",
+    filename: "node-os.mjs",
   },
 ]);
 
 export const importPolyfillsPlugin = (program: Program) => {
-  const config = program.config;
   return {
     name: "react-gnome-import-polyfills-esbuild-plugin",
     setup(build: esbuild.PluginBuild) {
@@ -54,7 +53,7 @@ export const importPolyfillsPlugin = (program: Program) => {
         }
       }
 
-      if (config.polyfills?.node || program.config.customPolyfills) {
+      if (program.config.customPolyfills) {
         build.onLoad(
           {
             filter: /.*/,

--- a/src/polyfills/fetch.ts
+++ b/src/polyfills/fetch.ts
@@ -73,7 +73,7 @@ async function fetch(url: RequestInfo, options: Partial<Request> = {} as any) {
 
   const responseBuffer = await new Promise<Uint8Array>((resolve) => {
     httpSession.queue_message(message, (_, msg) => {
-      resolve(msg!.response_body_data.unref_to_array() as any);
+      resolve(msg!.response_body_data.toArray() as any);
     });
   });
 

--- a/src/polyfills/websocket.ts
+++ b/src/polyfills/websocket.ts
@@ -109,7 +109,7 @@ namespace WsPolyfill {
         const origin = message.get_origin();
 
         if (type === Soup.WebsocketDataType.TEXT) {
-          const text = new TextDecoder().decode(data.unref_to_array());
+          const text = new TextDecoder().decode(data.toArray());
           this.#emitter.emit(
             WebSocketEventType.MESSAGE,
             Event.create({ origin, data: text })
@@ -117,7 +117,7 @@ namespace WsPolyfill {
         } else {
           this.#emitter.emit(
             WebSocketEventType.MESSAGE,
-            Event.create({ origin, data: data.unref_to_array() })
+            Event.create({ origin, data: data.toArray() })
           );
         }
       });

--- a/src/polyfills/xml-http-request.ts
+++ b/src/polyfills/xml-http-request.ts
@@ -547,7 +547,7 @@ const XMLHttpRequestPolyfill = (() => {
           : null;
         this._status = response.statusCode;
         this._statusText = response.statusText;
-        this._responseBuffer = response.rawResponseData.unref_to_array() as any;
+        this._responseBuffer = response.rawResponseData.toArray() as any;
 
         this._finishRequest(response.statusCode);
       } catch (e) {
@@ -590,7 +590,7 @@ const XMLHttpRequestPolyfill = (() => {
       this._contentType = contentType ? new ContentType(contentType) : null;
       this._status = status_code;
       this._statusText = reason_phrase;
-      this._responseBuffer = message.response_body_data.unref_to_array() as any;
+      this._responseBuffer = message.response_body_data.toArray() as any;
       this._responseURL = message.uri.to_string(true);
 
       this._finishRequest(status_code);


### PR DESCRIPTION
- a bug in polyfills for websockets and xhr, unrefing bytes from soup was causing critical errors
- import path resolution for node polyfills was broken